### PR TITLE
Je pinaille, mais petite faute d'orthographe.

### DIFF
--- a/Genma_Le_DNS.tex
+++ b/Genma_Le_DNS.tex
@@ -121,9 +121,9 @@ Conséquence : le site web ne s'affiche pas.
 \begin{frame}
 \frametitle{Utiliser le DNS de Google?}
 \justifying{
-\begin{block}{Google fourni un DNS}
+\begin{block}{Google fournit un DNS}
 \begin{itemize}
-\item Google fourni des serveurs DNS aux adresses très simples :  8.8.8.8 et 8.8.4.4 
+\item Google fournit des serveurs DNS aux adresses très simples :  8.8.8.8 et 8.8.4.4 
 \item En les utilisant, Google sait quels sont les sites que l'on consulte... 
 \end{itemize}
 Rq : en utilisant le DNS du FAI, il en est de même. De même si on cherche le nom d'un site web via Google et que l'on clique sur le résultat proposé...


### PR DESCRIPTION
"Google fourni" => "Google fournit"
